### PR TITLE
Add lightweight single-page marketing website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# khadourgroup-site
-Website for Khadour Group – Remedial &amp; Compliance Engineering
+# Khadour Group Website
+
+A fast, single-page marketing site for **Khadour Group – Remedial & Compliance Engineering**.
+
+## Structure
+
+- `index.html` – main page with hero, services, process and contact sections.
+- `styles.css` – lightweight CSS (no build step).
+- `assets/` – place for images or other media (currently empty).
+
+## Local development
+
+Open `index.html` directly in a browser or run a simple static server:
+
+```bash
+python -m http.server
+```
+
+Then visit <http://localhost:8000>.
+
+## Deployment to GitHub Pages
+
+1. Commit and push changes to the `main` branch.
+2. In the repository settings, enable **Pages** and choose **Deploy from branch**.
+3. Select the `main` branch and the root (`/`) folder, then save.
+4. GitHub will publish the site at `https://<username>.github.io/khadourgroup-site/`.
+
+## Contact
+
+- Email: [louay@khadourgroup.com.au](mailto:louay@khadourgroup.com.au)
+- Phone: 0400 000 000 (placeholder)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Khadour Group – Remedial &amp; Compliance Engineering in Sydney" />
+  <title>Khadour Group – Remedial &amp; Compliance Engineering</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header id="hero" class="section">
+    <div class="container">
+      <h1 class="logo">Khadour Group</h1>
+      <p class="tagline">Remedial &amp; Compliance Engineering</p>
+      <p>We diagnose building defects, specify compliant rectification and ensure works meet the NCC, Australian Standards and NSW rules.</p>
+      <a href="#contact" class="btn">Request an Inspection</a>
+      <p class="hero-contact">
+        <a href="tel:0400000000">0400&nbsp;000&nbsp;000</a> ·
+        <a href="mailto:louay@khadourgroup.com.au">louay@khadourgroup.com.au</a>
+      </p>
+    </div>
+  </header>
+
+  <main>
+    <section id="services" class="section">
+      <div class="container">
+        <h2>Services</h2>
+        <div class="cards">
+          <article class="card">
+            <h3>Defect Inspections &amp; Reports</h3>
+            <p>Detailed investigations and reporting for building defects.</p>
+          </article>
+          <article class="card">
+            <h3>Insurance &amp; Compliance Reports</h3>
+            <p>Evidence-based documentation for insurers and regulators.</p>
+          </article>
+          <article class="card">
+            <h3>Waterproofing &amp; Structural Design</h3>
+            <p>Designs for durable waterproofing and structural performance.</p>
+          </article>
+          <article class="card">
+            <h3>Remedial Project Support</h3>
+            <p>Scopes, tenders and quality assurance for remedial works.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="why-us" class="section alt">
+      <div class="container">
+        <h2>Why Us</h2>
+        <ul class="list">
+          <li>Evidence-based assessments</li>
+          <li>NCC &amp; Australian Standards compliance</li>
+          <li>Clear reports for strata and owners</li>
+          <li>Advanced inspection tools</li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="process" class="section">
+      <div class="container">
+        <h2>Process</h2>
+        <ol class="process">
+          <li>Book</li>
+          <li>Inspect</li>
+          <li>Report</li>
+          <li>Scope/Design</li>
+          <li>Support</li>
+        </ol>
+      </div>
+    </section>
+
+    <section id="areas" class="section alt">
+      <div class="container">
+        <h2>Service Areas</h2>
+        <p>Sydney and surrounding regions.</p>
+      </div>
+    </section>
+
+    <section id="contact" class="section">
+      <div class="container">
+        <h2>Contact</h2>
+        <form action="mailto:louay@khadourgroup.com.au" method="post" enctype="text/plain">
+          <label for="name">Name</label>
+          <input id="name" name="name" type="text" required />
+
+          <label for="email">Email</label>
+          <input id="email" name="email" type="email" required />
+
+          <label for="message">Message</label>
+          <textarea id="message" name="message" rows="4" required></textarea>
+
+          <button type="submit" class="btn">Send</button>
+        </form>
+        <p class="direct-contact">
+          <a href="mailto:louay@khadourgroup.com.au">louay@khadourgroup.com.au</a><br />
+          <a href="tel:0400000000">0400&nbsp;000&nbsp;000</a>
+        </p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="section alt">
+    <div class="container">
+      <p>&copy; Khadour Group. ABN 00 000 000 000</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,110 @@
+:root {
+  --primary: #1b3a8a;
+  --light: #f9fafb;
+  --dark: #1f2937;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  line-height: 1.6;
+  color: var(--dark);
+  background: #fff;
+}
+
+h1, h2, h3 {
+  line-height: 1.2;
+  margin-top: 0;
+}
+
+.section {
+  padding: 2rem 1rem;
+}
+
+.alt {
+  background: var(--light);
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.logo {
+  font-size: 1.875rem;
+  font-weight: 700;
+}
+
+.tagline {
+  font-size: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.btn {
+  display: inline-block;
+  background: var(--primary);
+  color: #fff;
+  padding: 0.75rem 1.25rem;
+  border-radius: 4px;
+  text-decoration: none;
+}
+
+.cards {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 600px) {
+  .cards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.card {
+  background: var(--light);
+  padding: 1rem;
+  border-radius: 4px;
+}
+
+.list {
+  padding-left: 1.25rem;
+}
+
+.process {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  padding: 0;
+}
+
+.process li {
+  background: var(--light);
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+}
+
+form {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 400px;
+}
+
+input, textarea {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.hero-contact a,
+.direct-contact a {
+  color: var(--primary);
+}
+
+.hero-contact {
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- Create single-page `index.html` with hero, services, process, service areas and contact form sections for Khadour Group
- Add minimal `styles.css` for responsive layout and call-to-action button styling
- Document project structure and GitHub Pages deployment in README

## Testing
- `python -m http.server` and `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_689db47101dc8333a57b0c893a795922